### PR TITLE
add the ability to search for hosts to soft delete if a list is NOT provided

### DIFF
--- a/roles/shadowman_soft_delete/defaults/main.yml
+++ b/roles/shadowman_soft_delete/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
-vm_names: "{{ vm_name.split(',') }}"
+
+shadowman_soft_delete_bool: true # Set this to false to disable the ACTUAL soft delete

--- a/roles/shadowman_soft_delete/tasks/get_aap_inventory_host_list.yml
+++ b/roles/shadowman_soft_delete/tasks/get_aap_inventory_host_list.yml
@@ -1,6 +1,5 @@
 ---
 
-
 - name: Set base URL for hosts
   ansible.builtin.set_fact:
     __base_url: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}/api/controller/v2/hosts?page_size=200"

--- a/roles/shadowman_soft_delete/tasks/get_aap_inventory_host_list.yml
+++ b/roles/shadowman_soft_delete/tasks/get_aap_inventory_host_list.yml
@@ -1,0 +1,81 @@
+---
+
+
+- name: Set base URL for hosts
+  ansible.builtin.set_fact:
+    __base_url: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}/api/controller/v2/hosts?page_size=200"
+
+- name: "Get hosts total count"
+  ansible.builtin.uri:
+    url: "{{ __base_url }}"
+    method: GET
+    return_content: true
+    status_code: 200
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ aap_token.token }}"
+  register: __host_inv_hosts_count
+
+- name: Set expected number of pages
+  ansible.builtin.set_fact:
+    __pages: "{{ (__host_inv_hosts_count.json.count // 200) + 1 }}"
+
+- name: Show expected number of hosts and pages
+  ansible.builtin.debug:
+    msg: "Expecting {{ __host_inv_hosts_count.json.count }} hosts across {{ __pages }} pages"
+
+- name: Create a list of hosts URLs
+  ansible.builtin.set_fact:
+    __host_inv_hosts_url_list: "{{ range(1, __pages | int + 1) | map('regex_replace', '^', __base_url2) | list }}"
+  vars:
+    __base_url2: "{{ __base_url }}&page="
+
+- name: "Get hosts"
+  ansible.builtin.uri:
+    url: "{{ item }}"
+    method: GET
+    return_content: true
+    status_code: 200
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ aap_token.token }}"
+  loop: "{{ __host_inv_hosts_url_list }}"
+  loop_control:
+    label: "{{ item }}"
+  until: __host_inv_hosts.status == 200
+  retries: 1
+  delay: 3
+  register: __host_inv_hosts
+
+- name: Update hosts list
+  ansible.builtin.set_fact:
+    __host_inv_hosts_list: >-
+      {{
+        __host_inv_hosts_list | default([]) +
+        item.json.results |
+        map(attribute='name') |
+        flatten |
+        list
+      }}
+  loop: "{{ __host_inv_hosts.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Assert host count matches
+  ansible.builtin.assert:
+    that:
+      - __host_inv_hosts_count.json.count == __host_inv_hosts_list | length
+    success_msg: "Host count matches: {{ __host_inv_hosts_count.json.count }} == {{ __host_inv_hosts_list | length }}"
+    fail_msg: "Host count mismatch: {{ __host_inv_hosts_count.json.count }} != {{ __host_inv_hosts_list | length }}"
+
+- name: Clean up duplicates from hosts list
+  ansible.builtin.set_fact:
+    __host_inv_hosts_list: >-
+      {{
+        __host_inv_hosts_list |
+        unique
+      }}
+
+- name: Show resulting unique host count
+  ansible.builtin.debug:
+    msg: "Unique hosts: {{ __host_inv_hosts_list | length }}"

--- a/roles/shadowman_soft_delete/tasks/get_host_metrics_host_list.yml
+++ b/roles/shadowman_soft_delete/tasks/get_host_metrics_host_list.yml
@@ -1,0 +1,69 @@
+---
+
+
+- name: Set base URL for host_metrics (already deleted = false)
+  ansible.builtin.set_fact:
+    __base_url: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}/api/controller/v2/host_metrics?page_size=200&deleted=false"
+
+- name: "Get host_metrics total count of non-deleted hosts"
+  ansible.builtin.uri:
+    url: "{{ __base_url }}"
+    method: GET
+    return_content: true
+    status_code: 200
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ aap_token.token }}"
+  register: __host_metrics_hosts_count
+
+- name: Set expected number of pages
+  ansible.builtin.set_fact:
+    __pages: "{{ (__host_metrics_hosts_count.json.count // 200) + 1 }}"
+
+- name: Show expected number of hosts and pages
+  ansible.builtin.debug:
+    msg: "Expecting {{ __host_metrics_hosts_count.json.count }} hosts across {{ __pages }} pages"
+
+- name: Create a list of host_metrics URLs
+  ansible.builtin.set_fact:
+    __host_metrics_url_list: "{{ range(1, __pages | int + 1) | map('regex_replace', '^', __base_url2) | list }}"
+  vars:
+    __base_url2: "{{ __base_url }}&page="
+
+- name: "Get host_metrics hosts"
+  ansible.builtin.uri:
+    url: "{{ item }}"
+    method: GET
+    return_content: true
+    status_code: 200
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ aap_token.token }}"
+  loop: "{{ __host_metrics_url_list }}"
+  loop_control:
+    label: "{{ item }}"
+  until: __host_metrics_hosts.status == 200
+  retries: 1
+  delay: 3
+  register: __host_metrics_hosts
+
+- name: Update host_metrics host list
+  ansible.builtin.set_fact:
+    __host_metrics_host_list: >-
+      {{
+        __host_metrics_host_list | default([]) +
+        item.json.results |
+        map(attribute='hostname') |
+        flatten |
+        list
+      }}
+  loop: "{{ __host_metrics_hosts.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Assert host count matches
+  ansible.builtin.assert:
+    that:
+      - __host_metrics_hosts_count.json.count == __host_metrics_host_list | length
+    success_msg: "Host count matches: {{ __host_metrics_hosts_count.json.count }} == {{ __host_metrics_host_list | length }}"
+    fail_msg: "Host count mismatch: {{ __host_metrics_hosts_count.json.count }} != {{ __host_metrics_host_list | length }}"

--- a/roles/shadowman_soft_delete/tasks/get_host_metrics_host_list.yml
+++ b/roles/shadowman_soft_delete/tasks/get_host_metrics_host_list.yml
@@ -1,6 +1,5 @@
 ---
 
-
 - name: Set base URL for host_metrics (already deleted = false)
   ansible.builtin.set_fact:
     __base_url: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}/api/controller/v2/host_metrics?page_size=200&deleted=false"

--- a/roles/shadowman_soft_delete/tasks/get_hosts_to_softdelete.yml
+++ b/roles/shadowman_soft_delete/tasks/get_hosts_to_softdelete.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Convert host arrays to lowercase
+  ansible.builtin.set_fact:
+    __host_metrics_host_list_lower: "{{ __host_metrics_host_list | map('lower') | list }}"
+    __host_inv_hosts_list_lower: "{{ __host_inv_hosts_list | map('lower') | list }}"
+
+- name: Get difference in hostnames
+  ansible.builtin.set_fact:
+    shadowman_soft_delete_vm_names: "{{ __host_metrics_host_list_lower | difference(__host_inv_hosts_list_lower) }}"

--- a/roles/shadowman_soft_delete/tasks/main.yml
+++ b/roles/shadowman_soft_delete/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 # tasks file for shadowman_soft_delete
 
-
 - name: "Setup authentication (block)"
   when: aap_token is not defined
   block:

--- a/roles/shadowman_soft_delete/tasks/main.yml
+++ b/roles/shadowman_soft_delete/tasks/main.yml
@@ -1,4 +1,57 @@
 ---
-- name: Loop to soft delete all hosts
-  ansible.builtin.include_tasks: softdelete.yml
-  loop: "{{ vm_names }}"
+# tasks file for shadowman_soft_delete
+
+
+- name: "Setup authentication (block)"
+  when: aap_token is not defined
+  block:
+    - name: Create a new token using gateway username/password
+      ansible.platform.token:
+        description: 'Creating token for shadowman_soft_delete'
+        scope: "write"
+        state: present
+        gateway_hostname: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}"
+        gateway_username: "{{ lookup('ansible.builtin.env', 'CONTROLLER_USERNAME') }}"
+        gateway_password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+      register: __authtoken_res
+      changed_when: false
+      tags:
+        - always
+
+
+- name: "Handle the tasks"
+  when: aap_token is defined
+  block:
+    - name: Convert provided string to list array if needed
+      ansible.builtin.set_fact:
+        shadowman_soft_delete_vm_names: "{{ vm_name.split(',') }}"
+      when:
+        - vm_name is defined
+        - vm_name | length > 0
+
+    - name: "Get hosts list if needed"
+      when: shadowman_soft_delete_vm_names is not defined
+      block:
+        - name: "Get hosts_metrics host list"
+          ansible.builtin.include_tasks: get_host_metrics_host_list.yml
+
+        - name: "Get AAP inventory host list"
+          ansible.builtin.include_tasks: get_aap_inventory_host_list.yml
+
+        - name: "Get hosts to soft delete (compare previous two lists)"
+          ansible.builtin.include_tasks: get_hosts_to_softdelete.yml
+
+    - name: Soft delete host(s)
+      ansible.builtin.include_tasks: softdelete.yml
+      when: shadowman_soft_delete_vm_names | length > 0
+
+  always:
+
+    - name: Delete the oauth token
+      ansible.platform.token:
+        gateway_hostname: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}"
+        gateway_token: "{{ aap_token }}"
+        existing_token: "{{ aap_token }}"
+        state: absent
+      tags:
+        - always

--- a/roles/shadowman_soft_delete/tasks/softdelete.yml
+++ b/roles/shadowman_soft_delete/tasks/softdelete.yml
@@ -32,3 +32,4 @@
     label: "{{ __host_item.__host | lower }}"
     loop_var: __host_item
   when: shadowman_soft_delete_bool | bool | default(false)
+  changed_when: true

--- a/roles/shadowman_soft_delete/tasks/softdelete.yml
+++ b/roles/shadowman_soft_delete/tasks/softdelete.yml
@@ -1,21 +1,34 @@
 ---
-- name: Get Host ID
-  ansible.builtin.uri:
-    url: https://{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}/api/controller/v2/host_metrics?hostname={{ item | trim }}
-    user: "{{ lookup('ansible.builtin.env', 'CONTROLLER_USERNAME') }}"
-    password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
-    method: GET
-    force_basic_auth: true
-    status_code: 200
-  register: host_metric
 
-- name: Soft Delete host
+- name: Show host count that will be soft deleted
+  ansible.builtin.debug:
+    msg: "Number of hosts that will be soft deleted: {{ shadowman_soft_delete_vm_names | length }}"
+
+- name: Get Host ID's
   ansible.builtin.uri:
-    url: https://{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}/api/controller/v2/host_metrics/{{ host_metric.json.results[0].id }}
-    user: "{{ lookup('ansible.builtin.env', 'CONTROLLER_USERNAME') }}"
-    password: "{{ lookup('ansible.builtin.env', 'CONTROLLER_PASSWORD') }}"
+    url: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}/api/controller/v2/host_metrics?hostname={{ __host | lower | trim }}"
+    method: GET
+    status_code: 200
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ aap_token.token }}"
+  loop: "{{ shadowman_soft_delete_vm_names }}"
+  loop_control:
+    label: "{{ __host | lower }}"
+    loop_var: __host
+  register: __host_metric
+
+- name: Soft Delete Host's
+  ansible.builtin.uri:
+    url: "{{ lookup('ansible.builtin.env', 'CONTROLLER_HOST') }}/api/controller/v2/host_metrics/{{ __host_item.json.results[0].id }}"
     method: DELETE
     follow_redirects: all
-    force_basic_auth: true
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ aap_token.token }}"
     status_code: 204
-  when: host_metric.json.results[0].id is defined
+  loop: "{{ __host_metric.results }}"
+  loop_control:
+    label: "{{ __host_item.__host | lower }}"
+    loop_var: __host_item
+  when: shadowman_soft_delete_bool | bool | default(false)


### PR DESCRIPTION
I added the ability to use API calls to poll the needed host lists in AAP and compare them to see if any hosts still exist in the host_metrics list (not ALREADY deleted) that NO longer exists in the host inventory.  This new list can/will then be soft-deleted. This can now be run on a normal schedule to keep the counts trued up.